### PR TITLE
fix breaking reaponsive page

### DIFF
--- a/static/web/css/base.css
+++ b/static/web/css/base.css
@@ -17,6 +17,30 @@
   color: red;
 }
 
+/* Mario - Handling Long Words and URLs  */
+/* https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/ */
+
+.detail-content a,
+.detail-content .description {
+
+  /* These are technically the same, but use both */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+  /* Instead use this non-standard one: */
+  word-break: break-word;
+
+  /* Adds a hyphen where the word breaks, if supported (No Blink) */
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+
+}
+
 /* Mario - Mobile menu */
 
 .menu-item {

--- a/web/templates/web/event_detail.html
+++ b/web/templates/web/event_detail.html
@@ -10,7 +10,7 @@
 
     <div class="detail-media">
         {% if obj.image_url %}
-        <img src="{{ obj.image_url }}">
+        <img src="{{ obj.image_url }}" class="mb-4 w-full">
         {% else %}
         {% load static %}
         <img rel="stylesheet" src="{% static 'web/images/placeholder-event.png' %}" class="mb-4 w-full">
@@ -19,7 +19,7 @@
 
     <div class="detail-content mb-4 lg:px-4">
 
-        <div class="text-sm mb-8 bg-gray-100 p-4 rounded">{{ obj.content | safe }}</div>
+        <div class="description text-sm mb-8 bg-gray-100 p-4 rounded">{{ obj.content | safe }}</div>
 
         <p class="mb-2"><i class="fal fa-university"></i> <a href="{{ obj.institution_url }}">{{ obj.institution }}</a></p>
 


### PR DESCRIPTION
- Added 100% width to detail image
- Handling Long Words and URLs (Forcing Breaks, Hyphenation, Ellipsis, etc) in the detail view