### PR TITLE
Feature/google translate

### DIFF
--- a/oerweekapi/settings.py
+++ b/oerweekapi/settings.py
@@ -5,6 +5,12 @@ import datetime
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 FE_DEPLOYMENT = False
 
+# ugly monkey patch, needed to get django-google-translate to initialized under (most probably only) Django 3.2
+from google_translate.apps import TranslateConfig
+
+TranslateConfig.name = "google_translate"
+# end of ugly monkey patch
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 

--- a/oerweekapi/settings.py
+++ b/oerweekapi/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = (
     "import_export",
     "constance",
     "constance.backends.database",
+    "google_translate",
     # our WagTail-based apps
     "contributor_profile",
     "gp",

--- a/requirements-fe.txt
+++ b/requirements-fe.txt
@@ -143,3 +143,5 @@ django-htmx>=1.13.0,==1.13.*
 
 django-constance>=2.9.1,==2.9.*
 django-constance[database]>=2.9.1,==2.9.*
+
+django-google-translate>=1.1,==1.*

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load static wagtailcore_tags wagtailuserbar %}
+{% load static google_translate wagtailcore_tags wagtailuserbar %}
 
 <!DOCTYPE html>
 <html data-lt-installed="true">
@@ -270,7 +270,7 @@
         </div>
     </div> {% comment %} .site-footer  {% endcomment %}
 
-    <footer class="site--footer2 bg-blue-800 text-gray-100 pb-10 pt-10 lg:pt-10">
+    <footer class="site--footer2 bg-blue-800 text-gray-100 pb-20 pt-10 lg:pt-10">
         <div class="container flex flex-col lg:flex-row justify-between text-sm">
             <div class="w-full lg:w-8/12 pb-4 lg:pb-0 flex gap-2">
                 <div class="cc-icons mr-1 flex-grow-0 flex-shrink-0">
@@ -290,10 +290,11 @@
         </div>
     </footer>
 
-    <nav
-        class="mobile-nav block bg-white text-gray-600 fixed md:hidden bottom-0 w-full h-58px z-50 w-screen max-w-full text-xs sf-hidden">
-
+    <nav class="mobile-nav block bg-white text-gray-600 fixed md:hidden bottom-0 w-full h-58px z-50 w-screen max-w-full text-xs sf-hidden">
     </nav>
+
+    <div class="google_translate_wrapper bg-blue-800 text-gray-100 notranslate">{% google_translate type='horizontal' language='en' %}</div>
+
 <script>
     function toggleMenu() {
         var header = document.getElementById("oewHeader");

--- a/web/static/web/css/base.css
+++ b/web/static/web/css/base.css
@@ -1069,7 +1069,7 @@ mark {
 	float: none;
 	height: 3.7rem;
 	position: fixed;
-	right: 8%;
+	right: 4%;
 	width: 14rem;
 
 	bottom: 0px;

--- a/web/static/web/css/base.css
+++ b/web/static/web/css/base.css
@@ -132,7 +132,7 @@
 }
 
 @media screen and (min-width: 1024px) {
-  
+
   .dropdown-content {
     display: none;
     position: absolute;
@@ -1060,4 +1060,24 @@ mark {
 .coming-up h2 {
   margin-top: 0;
   font-size: 1.5rem;
+}
+
+/* Google Translate wrapper */
+.google_translate_wrapper {
+	box-sizing: border-box;
+	display: block;
+	float: none;
+	height: 3.7rem;
+	position: fixed;
+	right: 8%;
+	width: 14rem;
+
+	bottom: 0px;
+	z-index: 999999;
+
+	border: 1px solid #1a52b2;
+	font-size: 10pt;
+	line-height: 17px;
+	padding: 3px 5px;
+	white-space: normal;
 }


### PR DESCRIPTION
This PR adds Google Translate to all pages in a similar fashion as it is on https://oeglobal.org/ . Look and feel is not exactly same given that `django-google-translate` for this Django site (while OE Global main site is WordPress based).